### PR TITLE
Removed extra spaces after marks

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -116,13 +116,7 @@ export default class HighlightrPlugin extends Plugin {
           }
         }
 
-        (selectedText && sufFirst === " ") ||
-        (!selectedText && sufFirst === " ")
-          ? editor.replaceSelection(`${prefix}${selectedText}${suffix}`)
-          : selectedText && sufFirst !== " "
-          ? editor.replaceSelection(`${prefix}${selectedText}${suffix} `)
-          : editor.replaceSelection(`${prefix}${selectedText}${suffix} `);
-
+        editor.replaceSelection(`${prefix}${selectedText}${suffix}`);
         return setCursor(1);
       };
 

--- a/src/ui/highlighterMenu.ts
+++ b/src/ui/highlighterMenu.ts
@@ -8,7 +8,7 @@ const highlighterMenu = (
   plugin: HighlightrPlugin,
   settings: HighlightrSettings,
   editor: Editor,
-  event: MouseEvent
+  event?: MouseEvent
 ): void => {
   if (editor && editor.hasFocus()) {
     const cursor = editor.getCursor("from");


### PR DESCRIPTION
To resolve this: https://github.com/chetachiezikeuzor/Highlightr-Plugin/issues/39

First, if I'm not mistaking the entire block:

```ts
 (selectedText && sufFirst === " ") ||
        (!selectedText && sufFirst === " ")
          ? editor.replaceSelection(`${prefix}${selectedText}${suffix}`)
          : selectedText && sufFirst !== " "
          ? editor.replaceSelection(`${prefix}${selectedText}${suffix} `)
          : editor.replaceSelection(`${prefix}${selectedText}${suffix} `);
```

is equivalent to: 

```ts
editor.replaceSelection(`${prefix}${selectedText}${suffix}${sufFirst !== " " ? " " : ""}`)
```

So basically the idea was to add a whitespece if the selection doesn't have another one aftewards. 
So if I select a `"word."` I get `"word ."`
I don't think it's correct behavior and so I dared to change it.