### PR TITLE
Add Word-Aware Highlighting, Improve Erase Behavior, and Optional Toggle Mode

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -1,5 +1,6 @@
 import { Editor, Menu, Plugin, PluginManifest } from "obsidian";
 import { wait } from "src/utils/util";
+import { selectMarkRegionIfInside, selectWordIfNone } from "src/utils/selectRegion";
 import addIcons from "src/icons/customIcons";
 import { HighlightrSettingTab } from "../settings/settingsTab";
 import { HighlightrSettings } from "../settings/settingsData";
@@ -39,22 +40,21 @@ export default class HighlightrPlugin extends Plugin {
       name: "Open Highlightr",
       icon: "highlightr-pen",
       editorCallback: (editor: EnhancedEditor) => {
-        // If toggling behavior is enabled and the selection has a highlight,
-        // use this command as a "remove highlight" instead of opening the menu.
-        const selection = editor.getSelection?.() ?? "";
+        const { markSelectionMade } = selectMarkRegionIfInside(editor, false);
+
+        // If toggling behavior is enabled and selection has a <mark>, erase instead of opening menu
         if (
           this.settings.useTogglingBehavior &&
-          selection &&
-          /<mark\b[^>]*>/i.test(selection)
+          markSelectionMade
         ) {
           this.eraseHighlight(editor);
-          editor.focus();
           return;
         }
 
-        !document.querySelector(".menu.highlighterContainer")
-          ? highlighterMenu(this.app, this.settings, editor)
-          : true;
+        if (!document.querySelector(".menu.highlighterContainer")) {
+          highlighterMenu(this.app, this.settings, editor);
+        }
+
       },
     });
 
@@ -78,8 +78,7 @@ export default class HighlightrPlugin extends Plugin {
   }
 
   eraseHighlight = (editor: Editor) => {
-    const from = editor.getCursor("from");
-    const to = editor.getCursor("to");
+    const { to, from, markSelectionMade } = selectMarkRegionIfInside(editor);
 
     const currentStr = editor.getRange(from, to);
     const newStr = currentStr
@@ -87,78 +86,89 @@ export default class HighlightrPlugin extends Plugin {
       .replace(/\<mark class.*?[^\>]\>/g, "")
       .replace(/\<\/mark>/g, "");
 
-      editor.replaceRange(newStr, from, to);
+    editor.replaceRange(newStr, from, to);
+    
+    if (this.settings.useTogglingBehavior && newStr.length > 0) {
+      const lines = newStr.split("\n");
 
-      if (this.settings.useTogglingBehavior && newStr.length > 0) {
-        const lines = newStr.split("\n");
-
-        let newTo;
-        if (lines.length === 1) {
-          newTo = {
-            line: from.line,
-            ch: from.ch + lines[0].length,
-          };
-        } else {
-          newTo = {
-            line: from.line + (lines.length - 1),
-            ch: lines[lines.length - 1].length,
-          };
-        }
-
-        editor.setSelection(from, newTo);
+      let newTo;
+      if (lines.length === 1) {
+        newTo = {
+          line: from.line,
+          ch: from.ch + lines[0].length,
+        };
+      } else {
+        newTo = {
+          line: from.line + (lines.length - 1),
+          ch: lines[lines.length - 1].length,
+        };
       }
 
-      editor.focus();
+      if (!markSelectionMade) {
+        // If user actually had text selected -> keep it selected after erase
+        editor.setSelection(from, newTo);
+      } else {
+        // If selection was auto-created by the helper -> collapse to caret
+        editor.setCursor(newTo);
+      }
+    } else if (markSelectionMade) {
+      // Toggling behavior is off, but we auto-selected a mark region.
+      // Collapse selection so we don't leave an auto-selection hanging.
+      editor.setCursor(from);
+    }
+
+    editor.focus();
   };
 
   generateCommands(editor: Editor) {
     this.settings.highlighterOrder.forEach((highlighterKey: string) => {
       const applyCommand = (command: CommandPlot, editor: Editor) => {
-        const selectedText = editor.getSelection();
-        const curserStart = editor.getCursor("from");
-        const curserEnd = editor.getCursor("to");
-        const prefix = command.prefix;
+        let { selection: selectedText, from: curserStart, to: curserEnd, wordSelected } =
+          selectWordIfNone(editor);
+
+        const prefix = command.prefix; 
         const suffix = command.suffix || prefix;
-          if (this.settings.useTogglingBehavior) {
-            // If the selection already contains any <mark>, we treat this as "remove highlight"
-            if (selectedText && /<mark\b[^>]*>/i.test(selectedText)) {
-              const newStr = selectedText
-                .replace(/\<mark style.*?[^\>]\>/g, "")
-                .replace(/\<mark class.*?[^\>]\>/g, "")
-                .replace(/\<\/mark>/g, "");
 
-              editor.replaceSelection(newStr);
+        if (this.settings.useTogglingBehavior) {
+          // If the selection already contains any <mark>, we treat this as "remove highlight"
+          if (selectedText && /<mark\b[^>]*>/i.test(selectedText)) {
+            const newStr = selectedText
+              .replace(/\<mark style.*?[^\>]\>/g, "")
+              .replace(/\<mark class.*?[^\>]\>/g, "")
+              .replace(/\<\/mark>/g, "");
 
-              // Re-select the resulting text (now without the <mark> tags)
+            editor.replaceSelection(newStr);
+
+            // Re-select the resulting text (now without the <mark> tags)
+            const newTo = {
+              line: curserStart.line,
+              ch: curserStart.ch + newStr.length,
+            };
+            editor.setSelection(curserStart, newTo);
+            return;
+          } else {
+            // If no <mark> in selection, apply highlight with this command's prefix/suffix
+            editor.replaceSelection(`${prefix}${selectedText}${suffix}`);
+
+            if (selectedText && selectedText.length > 0 && !wordSelected) {
+              // Select the entire <mark ...>selectedText</mark> region
               const newTo = {
                 line: curserStart.line,
-                ch: curserStart.ch + newStr.length,
+                ch:
+                  curserStart.ch +
+                  prefix.length +
+                  selectedText.length +
+                  suffix.length,
               };
               editor.setSelection(curserStart, newTo);
-              return;
             } else {
-              // No <mark> in selection: apply highlight with this command's prefix/suffix
-              editor.replaceSelection(`${prefix}${selectedText}${suffix}`);
-
-              if (selectedText && selectedText.length > 0) {
-                // Select the entire <mark ...>selectedText</mark> region
-                const newTo = {
-                  line: curserStart.line,
-                  ch:
-                    curserStart.ch +
-                    prefix.length +
-                    selectedText.length +
-                    suffix.length,
-                };
-                editor.setSelection(curserStart, newTo);
-              } else {
-                // No prior selection: place cursor between prefix and suffix
-                const caretPos = curserStart.ch + prefix.length;
-                editor.setCursor(curserStart.line, caretPos);
-              }
-              return;
+              // No prior selection: place cursor between prefix and suffix
+              const caretPos = curserStart.ch + prefix.length;
+              editor.setCursor(curserStart.line, caretPos);
             }
+            return;
           }
+        }
 
         const setCursor = (mode: number) => {
           editor.setCursor(
@@ -202,13 +212,7 @@ export default class HighlightrPlugin extends Plugin {
 
         editor.replaceSelection(`${prefix}${selectedText}${suffix}`);
 
-        // If no selection beforehand (just caret)
-        if (!selectedText) {
-          return setCursor(1);
-        }
-
         if (this.settings.useTogglingBehavior) {
-          // Select the entire <mark ...>selectedText</mark> block
           const newFrom = {
             line: curserStart.line + command.line,
             ch: curserStart.ch,
@@ -222,9 +226,9 @@ export default class HighlightrPlugin extends Plugin {
               suffix.length,
           };
           editor.setSelection(newFrom, newTo);
-        } else {
-          setCursor(1);
-        }
+        } 
+
+        return setCursor(1);
       };
 
       type CommandPlot = {

--- a/src/settings/settingsData.ts
+++ b/src/settings/settingsData.ts
@@ -17,6 +17,7 @@ export interface HighlightrSettings {
   highlighterMethods: string;
   highlighters: Highlighters;
   highlighterOrder: string[];
+  useTogglingBehavior: boolean;
 }
 
 const DEFAULT_SETTINGS: HighlightrSettings = {
@@ -34,6 +35,7 @@ const DEFAULT_SETTINGS: HighlightrSettings = {
     Grey: "#CACFD9A6",
   },
   highlighterOrder: [],
+  useTogglingBehavior: false, 
 };
 
 DEFAULT_SETTINGS.highlighterOrder = Object.keys(DEFAULT_SETTINGS.highlighters);

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -86,6 +86,20 @@ export class HighlightrSettingTab extends PluginSettingTab {
 
     stylesSetting.infoEl.appendChild(styleDemo());
 
+    new Setting(containerEl)
+      .setName("Use toggling behavior")
+      .setDesc(
+        "When enabled, highlight commands will toggle: if the current selection is already highlighted, the same hotkey will remove the highlight instead. This also keeps the entire <mark>...</mark> region selected after applying or removing highlights."
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.useTogglingBehavior)
+          .onChange(async (value) => {
+            this.plugin.settings.useTogglingBehavior = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
     const highlighterSetting = new Setting(containerEl);
 
     highlighterSetting

--- a/src/utils/selectRegion.ts
+++ b/src/utils/selectRegion.ts
@@ -1,0 +1,128 @@
+
+import type { Editor, EditorPosition } from "obsidian";
+
+
+
+export interface MarkRegionResult {
+  selection: string;
+  markSelectionMade: boolean;
+  from: EditorPosition;
+  to: EditorPosition;
+}
+
+/**
+ * Expands the selection if the cursor is inside a <mark ...>...</mark> region.
+ * - If text is already selected, nothing changes.
+ * - If no text is selected and the cursor is inside a <mark>, selects the full mark region.
+ * - Otherwise selection stays empty.
+ *
+ * Returns:
+ *   selection           → updated selected text
+ *   markSelectionMade   → true if we auto-selected a <mark> region
+ *   from, to            → updated cursor positions
+ */
+export function selectMarkRegionIfInside(editor: Editor, makeSelection=true): MarkRegionResult {
+  let selection = editor.getSelection() ?? "";
+  let markSelectionMade = false;
+
+  const cursor = editor.getCursor();
+  const line = cursor.line;
+  const lineText = editor.getLine(line) ?? "";
+
+  // Only attempt to expand if nothing is selected
+  if (!selection) {
+    let markStart = -1;
+    let markEnd = -1;
+    let searchPos = 0;
+
+    while (true) {
+      const openIdx = lineText.indexOf("<mark", searchPos);
+      if (openIdx === -1) break;
+
+      const closeIdxRaw = lineText.indexOf("</mark>", openIdx);
+      if (closeIdxRaw === -1) break;
+
+      const closeIdx = closeIdxRaw + "</mark>".length;
+
+      // Check if cursor is inside this <mark>...</mark> block
+      if (cursor.ch >= openIdx && cursor.ch <= closeIdx) {
+        markStart = openIdx;
+        markEnd = closeIdx;
+        break;
+      }
+
+      searchPos = closeIdx;
+    }
+
+    if (markStart !== -1 && markEnd !== -1) {
+      if (makeSelection) {
+        // Select the entire <mark ...>...</mark> block
+        editor.setSelection(
+          { line, ch: markStart },
+          { line, ch: markEnd }
+        );
+      }
+
+      selection = editor.getSelection() ?? "";
+      markSelectionMade = true;
+    }
+  }
+
+  const from = editor.getCursor("from");
+  const to = editor.getCursor("to");
+
+  return { selection, markSelectionMade, from, to };
+}
+
+export interface WordSelectionResult {
+  selection: string;
+  from: EditorPosition;
+  to: EditorPosition;
+  wordSelected: boolean; // true if we auto-selected a word
+}
+
+/**
+ * If nothing is selected, expands selection to the "word" under the cursor.
+ * A "word" is defined as continuous characters bounded by spaces.
+ *
+ * Returns:
+ *   selection     → updated selection (word or original)
+ *   from, to      → updated selection bounds
+ *   wordSelected  → true if the helper auto-selected a word
+ */
+export function selectWordIfNone(editor: Editor): WordSelectionResult {
+  let selection = editor.getSelection() ?? "";
+  let wordSelected = false;
+
+  if (!selection) {
+    const cursor = editor.getCursor();
+    const line = cursor.line;
+    const lineText = editor.getLine(line) ?? "";
+
+    let startCh = cursor.ch;
+    let endCh = cursor.ch;
+
+    // Move left until space or start of line
+    while (startCh > 0 && lineText[startCh - 1] !== " ") {
+      startCh--;
+    }
+
+    // Move right until space or end of line
+    while (endCh < lineText.length && lineText[endCh] !== " ") {
+      endCh++;
+    }
+
+    editor.setSelection(
+      { line, ch: startCh },
+      { line, ch: endCh }
+    );
+
+    selection = editor.getSelection() ?? "";
+    wordSelected = true;
+  }
+
+  const from = editor.getCursor("from");
+  const to = editor.getCursor("to");
+
+  return { selection, from, to, wordSelected };
+}


### PR DESCRIPTION
## **Summary**

This PR introduces several UX improvements to Highlightr while preserving all existing default behavior. The main feature additions include:

1. **Word-aware highlighting**
2. **Automatic selection of highlighting tags when unhighlighting command is triggered**
3. **An optional new “Toggle Highlighting” mode** that unifies highlight & unhighlight behavior and preserves text selections

---

## **Highlights of the Changes**

### **1. Highlight a word by simply pressing the keybind**
If the user presses a highlight keybind without selecting text, Highlightr now:

- Identifies the word under the cursor (space-delimited)
- Automatically highlights that word
- Behaves similarly to Obsidian’s native word-selection tools

This allows for much faster highlighting without requiring manual selection.

---

### **2. Smarter unhighlighting when inside a `<mark>` region**
If the user triggers an erase action (either through the original *Remove Highlight* command or via the new toggle mode) while their cursor is inside a highlight:

- The plugin automatically detects the entire `<mark>…</mark>` block
- Removes the highlight without requiring the user to manually select anything

Works with both inline-style and CSS-class-based highlight markup.

---

### **3. New setting: “Use toggling behavior”**
A new setting allows users to unify highlight and unhighlight actions into a **single toggle command**.

When enabled:

- Pressing a highlight keybind on already-highlighted text removes the highlight
- Text selections persist after toggling (helpful for switching colors)
  - Unless no selection was made in the first place (via either of the above changes), in which case there will continue to be no selection. 

When disabled (default):

- The plugin behaves exactly as before—no changes unless the user opts in.

---

## **Why This Matters**

These enhancements significantly streamline the keyboard-driven workflow. Highlighting and unhighlighting become much faster, more intuitive, and more consistent. Power users gain a more efficient editing experience without any downside for existing users. It also makes the experience more inline with other native-Obsidian features, like bolding, italics, and the native highlight. 


